### PR TITLE
Integrate database layer and add dashboard auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+*.log
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# DiyaaHoneyPot
+# DiyaaHoney
+
+## Quick Start for Group Members
+```bash
+git clone <repo-url>
+cd DiyaaHoney
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python setup_db.py  # creates default admin
+python honeypot.py &
+python intrusion_detector.py &
+python dashboard.py
+```
+
+### Other scripts
+- `generate_fake_hits.sh` – send 10 test connections
+- `tests/test_db.py` – run with `pytest`

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,116 +1,108 @@
-# dashboard.py
-from flask import Flask, render_template_string, jsonify
 import os
-from datetime import datetime
+import bcrypt
+from flask import Blueprint, Flask, render_template, request, redirect, url_for, flash
+from flask_login import (
+    LoginManager,
+    login_user,
+    logout_user,
+    login_required,
+    UserMixin,
+    current_user,
+)
+from sqlalchemy import text
+from db_utils import engine
 
-app = Flask(__name__)
+bp = Blueprint("dashboard", __name__, template_folder="templates")
+login_manager = LoginManager()
+login_manager.login_view = "dashboard.login"
 
-# HTML template with AJAX update
-TEMPLATE = """
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Intrusion Log Dashboard</title>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-</head>
-<body class="bg-light">
-    <div class="container my-5">
-        <h1 class="mb-2 text-center">Intrusion Log Dashboard</h1>
-        <div class="d-flex justify-content-between align-items-center mb-3">
-            <small class="text-muted" id="lastRefresh">Last refresh: {{ now }}</small>
-            <input type="text" id="search" onkeyup="filterTable()" class="form-control w-25" placeholder="Search logs…">
-        </div>
-        <div class="card shadow-sm">
-            <div class="card-body p-0">
-                <table class="table table-striped table-hover mb-0" id="logTable">
-                    <thead class="thead-dark">
-                        <tr>
-                            <th scope="col">Timestamp</th>
-                            <th scope="col">Message</th>
-                        </tr>
-                    </thead>
-                    <tbody id="logBody">
-                        {% for timestamp, message in entries %}
-                        <tr>
-                            <td>{{ timestamp }}</td>
-                            <td>{{ message }}</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
 
-    <script>
-        function filterTable() {
-            const query = document.getElementById('search').value.toLowerCase();
-            document.querySelectorAll('#logBody tr').forEach(row => {
-                row.style.display = row.innerText.toLowerCase().includes(query) ? '' : 'none';
-            });
-        }
+class User(UserMixin):
+    def __init__(self, id: int, username: str, password: str, role: str) -> None:
+        self.id = id
+        self.username = username
+        self.password = password
+        self.role = role
 
-        async function fetchLogs() {
-            const res = await fetch('/api/logs');
-            const data = await res.json();
-            const tbody = document.getElementById('logBody');
-            const searchTerm = document.getElementById('search').value.toLowerCase();
-            tbody.innerHTML = '';
-            data.entries.forEach(([timestamp, message]) => {
-                const row = document.createElement('tr');
-                row.innerHTML = `<td>${timestamp}</td><td>${message}</td>`;
-                if (!timestamp.toLowerCase().includes(searchTerm) && !message.toLowerCase().includes(searchTerm)) {
-                    row.style.display = 'none';
-                }
-                tbody.appendChild(row);
-            });
-            document.getElementById('lastRefresh').textContent = 'Last refresh: ' + data.now;
-        }
 
-        // Initial fetch and periodic updates
-        fetchLogs();
-        setInterval(fetchLogs, 10000);
-    </script>
-</body>
-</html>
-"""
+def _row_to_user(row) -> User:
+    return User(row["id"], row["username"], row["password"], row["role"])
 
-LOG_FILES = ['honeypot.log', 'alerts.log']
 
-@app.route('/')
-def index():
-    # Render initial page with combined logs
-    entries = []
-    for log_file in LOG_FILES:
-        if os.path.exists(log_file):
-            with open(log_file) as f:
-                lines = f.read().splitlines()
-            for line in lines:
-                parts = line.strip().split(' - ', 1)
-                if len(parts) == 2:
-                    entries.append((parts[0], f"[{os.path.basename(log_file)}] {parts[1]}"))
-    # Sort by timestamp descending
-    entries.sort(key=lambda x: x[0], reverse=True)
-    now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    return render_template_string(TEMPLATE, entries=entries, now=now)
+@login_manager.user_loader
+def load_user(user_id: str):
+    with engine.connect() as conn:
+        row = conn.execute(
+            text("SELECT * FROM users WHERE id = :id"), {"id": int(user_id)}
+        ).mappings().first()
+    return _row_to_user(row) if row else None
 
-@app.route('/api/logs')
-def api_logs():
-    # Provide combined logs as JSON
-    entries = []
-    for log_file in LOG_FILES:
-        if os.path.exists(log_file):
-            with open(log_file) as f:
-                lines = f.read().splitlines()
-            for line in lines:
-                parts = line.strip().split(' - ', 1)
-                if len(parts) == 2:
-                    entries.append((parts[0], f"[{os.path.basename(log_file)}] {parts[1]}"))
-    entries.sort(key=lambda x: x[0], reverse=True)
-    now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    return jsonify({'now': now, 'entries': entries})
 
-if __name__ == '__main__':
-    app.run(port=5000, debug=True)
+@bp.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form["username"]
+        password = request.form["password"]
+        with engine.connect() as conn:
+            row = conn.execute(
+                text("SELECT * FROM users WHERE username = :u"), {"u": username}
+            ).mappings().first()
+        if row and bcrypt.checkpw(password.encode(), row["password"].encode()):
+            login_user(_row_to_user(row))
+            return redirect(url_for("dashboard.dashboard"))
+        flash("Invalid credentials", "danger")
+    return render_template("login.html")
+
+
+@bp.route("/logout")
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for("dashboard.login"))
+
+
+@bp.route("/")
+@login_required
+def dashboard():
+    ip = request.args.get("ip")
+    start = request.args.get("start")
+    end = request.args.get("end")
+    alert_only = request.args.get("alert_only")
+
+    filters = []
+    params = {}
+    if ip:
+        filters.append("c.ip = :ip")
+        params["ip"] = ip
+    if start:
+        filters.append("c.ts >= :start")
+        params["start"] = start
+    if end:
+        filters.append("c.ts <= :end")
+        params["end"] = end
+    if alert_only:
+        filters.append("a.id IS NOT NULL")
+
+    where = "WHERE " + " AND ".join(filters) if filters else ""
+    query = text(
+        """SELECT c.ip, c.port, c.ts, a.message
+               FROM connections c
+               LEFT JOIN alerts a ON c.ip = a.ip
+               %s
+               ORDER BY c.ts DESC""" % where
+    )
+    with engine.connect() as conn:
+        rows = conn.execute(query, params).fetchall()
+    return render_template("dashboard.html", rows=rows, user=current_user)
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.secret_key = os.getenv("SECRET_KEY", "devkey")
+    login_manager.init_app(app)
+    app.register_blueprint(bp)
+    return app
+
+
+if __name__ == "__main__":
+    create_app().run(debug=True)

--- a/db_utils.py
+++ b/db_utils.py
@@ -1,0 +1,65 @@
+import os
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import create_engine, MetaData, Table, Column, Integer, String, DateTime, ForeignKey, text
+from sqlalchemy.engine import Engine
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///diyaa.db")
+engine: Engine = create_engine(DATABASE_URL)
+metadata = MetaData()
+
+users = Table(
+    "users",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("username", String, unique=True, nullable=False),
+    Column("password", String, nullable=False),
+    Column("role", String, nullable=False, default="viewer"),
+)
+
+connections = Table(
+    "connections",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("ip", String, nullable=False),
+    Column("port", Integer, nullable=False),
+    Column("ts", DateTime, nullable=False, default=datetime.utcnow),
+    Column("user_id", Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+)
+
+alerts = Table(
+    "alerts",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("ip", String, nullable=False),
+    Column("message", String, nullable=False),
+    Column("ts", DateTime, nullable=False, default=datetime.utcnow),
+)
+
+metadata.create_all(engine)
+
+
+def insert_connection(ip: str, port: int, ts: datetime, user_id: Optional[int] = None) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            connections.insert().values(ip=ip, port=port, ts=ts, user_id=user_id)
+        )
+
+
+def insert_alert(ip: str, message: str, ts: datetime) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            alerts.insert().values(ip=ip, message=message, ts=ts)
+        )
+
+
+__all__ = [
+    "engine",
+    "insert_connection",
+    "insert_alert",
+    "users",
+    "connections",
+    "alerts",
+    "metadata",
+]

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,0 +1,23 @@
+dbdiagram.io syntax
+
+Table users {
+  id int [pk, increment]
+  username varchar [unique]
+  password varchar
+  role varchar
+}
+
+Table connections {
+  id int [pk, increment]
+  ip varchar
+  port int
+  ts timestamp
+  user_id int [ref: > users.id]
+}
+
+Table alerts {
+  id int [pk, increment]
+  ip varchar
+  message varchar
+  ts timestamp
+}

--- a/docs/sample_queries.sql
+++ b/docs/sample_queries.sql
@@ -1,0 +1,17 @@
+-- Top 5 attacking IPs in the last 24 hours
+SELECT ip, COUNT(*) AS attempts
+FROM connections
+WHERE ts > NOW() - INTERVAL '24 hours'
+GROUP BY ip
+ORDER BY attempts DESC
+LIMIT 5;
+
+-- Delete connections older than 30 days
+DELETE FROM connections
+WHERE ts < NOW() - INTERVAL '30 days';
+
+-- Who was logged in when an alert fired
+SELECT a.ip, a.message, u.username
+FROM alerts a
+JOIN connections c ON a.ip = c.ip
+LEFT JOIN users u ON c.user_id = u.id;

--- a/generate_fake_hits.sh
+++ b/generate_fake_hits.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+for i in {1..10}; do
+  nc -z 127.0.0.1 2222 >/dev/null 2>&1
+  sleep 0.1
+done

--- a/honeypot.py
+++ b/honeypot.py
@@ -17,6 +17,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 from datetime import datetime
 from alerts import send_email_alert, send_mqtt_alert, trigger_led
+from db_utils import insert_connection
 
 # ── Paths ────────────────────────────────────────────────────────────────
 BASE_DIR      = os.path.dirname(os.path.abspath(__file__))
@@ -46,11 +47,13 @@ BANNER     = b"SSH-2.0-Honeypot_1.0\r\n"
 
 def handle_client(client_sock: socket.socket, addr):
     ip, port = addr
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    now = datetime.now()
+    timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
     try:
         logger.info(f"Connection from {ip}:{port}")
         client_sock.sendall(BANNER)
         alert_msg = f"Connection from {ip}:{port} at {timestamp}"
+        insert_connection(ip, port, now)
         send_email_alert(alert_msg)   # real email via alerts.py
         send_mqtt_alert(alert_msg)    # stub / simulated MQTT
         trigger_led(alert_msg)        # stub / simulated LED/Buzzer

--- a/intrusion_detector.py
+++ b/intrusion_detector.py
@@ -9,6 +9,8 @@ import time
 import re
 import logging
 from alerts import send_email_alert, send_mqtt_alert, trigger_led
+from db_utils import insert_alert
+from datetime import datetime
 
 # ── CONFIGURATION ────────────────────────────────────────────────────────────
 THRESHOLD       = 3          # attempts before alert fires
@@ -70,6 +72,8 @@ class IntrusionDetector:
         for ip, total in self._count_attempts().items():
             if total >= self.threshold and ip not in self.alerted_ips:
                 msg = f"{total} failed attempts detected from {ip}"
+                now = datetime.utcnow()
+                insert_alert(ip, msg, now)
                 send_email_alert(msg)         # real email (alerts.py)
                 send_mqtt_alert(msg)          # stub / simulated MQTT
                 trigger_led(msg)              # stub / simulated LED/Buzzer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+flask
+flask-login
+sqlalchemy
+psycopg2-binary
+bcrypt
+pytest

--- a/setup_db.py
+++ b/setup_db.py
@@ -1,0 +1,20 @@
+import os
+import bcrypt
+from sqlalchemy import create_engine
+from db_utils import metadata, users
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///diyaa.db")
+engine = create_engine(DATABASE_URL)
+metadata.create_all(engine)
+
+DEFAULT_USERNAME = os.getenv("ADMIN_USER", "admin")
+DEFAULT_PASSWORD = os.getenv("ADMIN_PASS", "admin")
+
+with engine.begin() as conn:
+    result = conn.execute(users.select().where(users.c.username == DEFAULT_USERNAME)).fetchone()
+    if not result:
+        hashed = bcrypt.hashpw(DEFAULT_PASSWORD.encode(), bcrypt.gensalt()).decode()
+        conn.execute(users.insert().values(username=DEFAULT_USERNAME, password=hashed, role="admin"))
+        print(f"Created default admin user '{DEFAULT_USERNAME}' with password '{DEFAULT_PASSWORD}'")
+    else:
+        print("Admin user already exists")

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,1 @@
+body { padding-bottom: 40px; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <title>DiyaaHoney Dashboard</title>
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('dashboard.dashboard') }}">DiyaaHoney</a>
+        {% if current_user.is_authenticated %}
+        <div class="d-flex">
+          <a class="nav-link text-white" href="{{ url_for('dashboard.logout') }}">Logout</a>
+        </div>
+        {% endif %}
+      </div>
+    </nav>
+    <div class="container">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }}">{{ message }}</div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+{% block content %}
+<form class="row g-3 mb-3" method="get">
+  <div class="col-md-3">
+    <input type="text" class="form-control" name="ip" placeholder="IP" value="{{ request.args.get('ip','') }}">
+  </div>
+  <div class="col-md-3">
+    <input type="date" class="form-control" name="start" value="{{ request.args.get('start','') }}">
+  </div>
+  <div class="col-md-3">
+    <input type="date" class="form-control" name="end" value="{{ request.args.get('end','') }}">
+  </div>
+  <div class="col-md-2 form-check align-self-center">
+    <input class="form-check-input" type="checkbox" name="alert_only" value="1" {% if request.args.get('alert_only') %}checked{% endif %}>
+    <label class="form-check-label">Alerts only</label>
+  </div>
+  <div class="col-md-1">
+    <button class="btn btn-secondary w-100" type="submit">Filter</button>
+  </div>
+</form>
+
+<input type="text" id="search" class="form-control mb-3" placeholder="Search...">
+
+<table class="table table-striped" id="connTable">
+  <thead>
+    <tr><th>IP</th><th>Port</th><th>Timestamp</th><th>Alert</th></tr>
+  </thead>
+  <tbody>
+    {% for ip, port, ts, message in rows %}
+    <tr>
+      <td>{{ ip }}</td>
+      <td>{{ port }}</td>
+      <td>{{ ts }}</td>
+      <td>{{ message or '' }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<script>
+document.getElementById('search').addEventListener('keyup', function() {
+  const q = this.value.toLowerCase();
+  document.querySelectorAll('#connTable tbody tr').forEach(function(row){
+    row.style.display = row.innerText.toLowerCase().includes(q) ? '' : 'none';
+  });
+});
+</script>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-4">
+    <form method="post">
+      <h2 class="mb-3">Login</h2>
+      <div class="mb-3">
+        <label class="form-label">Username</label>
+        <input name="username" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Password</label>
+        <input type="password" name="password" class="form-control" required>
+      </div>
+      <button class="btn btn-primary w-100" type="submit">Login</button>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,20 @@
+import datetime
+import importlib
+import sys
+from pathlib import Path
+from sqlalchemy import text
+
+def test_insert_connection(monkeypatch, tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    db_utils = importlib.import_module("db_utils")
+    importlib.reload(db_utils)
+
+    for i in range(10):
+        db_utils.insert_connection(f"10.0.0.{i}", 2222, datetime.datetime.utcnow())
+
+    with db_utils.engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM connections")).scalar()
+
+    assert count == 10


### PR DESCRIPTION
## Summary
- Persist honeypot connections and IDS alerts via SQLAlchemy helpers
- Add setup script, ERD, and sample SQL queries for PostgreSQL
- Refactor dashboard into Flask blueprint with login/logout and filters
- Include tests and utility scripts

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5dde74e5c83338ffe8bff1b529470