### PR TITLE
Automatic DB setup and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,21 @@ cd DiyaaHoney
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-python setup_db.py  # creates default admin
 python honeypot.py &
 python intrusion_detector.py &
 python dashboard.py
 ```
+
+### Database setup
+The application uses SQLite by default. On startup it checks the database
+connection and creates the database file, required tables and a default
+administrator account if they are missing.
+
+If your system does not have SQLite, you can download it from
+[sqlite.org](https://sqlite.org/download.html).
+
+You can run `python setup_db.py` manually to perform the initialization at
+any time.
 
 ### Other scripts
 - `generate_fake_hits.sh` – send 10 test connections

--- a/setup_db.py
+++ b/setup_db.py
@@ -1,20 +1,4 @@
-import os
-import bcrypt
-from sqlalchemy import create_engine
-from db_utils import metadata, users
+from db_utils import init_db
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///diyaa.db")
-engine = create_engine(DATABASE_URL)
-metadata.create_all(engine)
-
-DEFAULT_USERNAME = os.getenv("ADMIN_USER", "admin")
-DEFAULT_PASSWORD = os.getenv("ADMIN_PASS", "admin")
-
-with engine.begin() as conn:
-    result = conn.execute(users.select().where(users.c.username == DEFAULT_USERNAME)).fetchone()
-    if not result:
-        hashed = bcrypt.hashpw(DEFAULT_PASSWORD.encode(), bcrypt.gensalt()).decode()
-        conn.execute(users.insert().values(username=DEFAULT_USERNAME, password=hashed, role="admin"))
-        print(f"Created default admin user '{DEFAULT_USERNAME}' with password '{DEFAULT_PASSWORD}'")
-    else:
-        print("Admin user already exists")
+if __name__ == "__main__":
+    init_db(verbose=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,6 +28,9 @@
       {% endwith %}
       {% block content %}{% endblock %}
     </div>
+    <footer class="text-center mt-5">
+      <small>If you need SQLite, download it <a href="https://sqlite.org/download.html" target="_blank">here</a>.</small>
+    </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   </body>
 </html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -27,12 +27,14 @@
   </thead>
   <tbody>
     {% for ip, port, ts, message in rows %}
-    <tr>
+    <tr class="{{ 'table-danger' if message else '' }}">
       <td>{{ ip }}</td>
       <td>{{ port }}</td>
       <td>{{ ts }}</td>
       <td>{{ message or '' }}</td>
     </tr>
+    {% else %}
+    <tr><td colspan="4" class="text-center">No connections found</td></tr>
     {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- ensure database initializes automatically with default admin
- highlight alert rows and show empty-state message in dashboard
- add footer link to SQLite download and document auto setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e059936c8333a77639cba3f0a9bd