### PR TITLE
Add stats endpoint and admin SQL query interface

### DIFF
--- a/static/charts.js
+++ b/static/charts.js
@@ -1,0 +1,16 @@
+fetch('/stats')
+  .then(r => r.json())
+  .then(data => {
+    const ctx = document.getElementById('ipChart');
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: data.map(d => d.ip),
+        datasets: [{
+          label: 'Hits',
+          data: data.map(d => d.hits),
+          backgroundColor: 'rgba(54, 162, 235, 0.5)'
+        }]
+      }
+    });
+  });

--- a/templates/charts.html
+++ b/templates/charts.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<canvas id="ipChart" width="400" height="200"></canvas>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{{ url_for('static', filename='charts.js') }}"></script>
+{% endblock %}

--- a/templates/query.html
+++ b/templates/query.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post">
+  <div class="mb-3">
+    <textarea class="form-control" name="sql" rows="5">{{ sql }}</textarea>
+  </div>
+  <button class="btn btn-primary" type="submit">Run</button>
+</form>
+{% if rows %}
+<table class="table table-striped mt-3">
+  <thead>
+    <tr>
+      {% for h in headers %}<th>{{ h }}</th>{% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>{% for cell in row %}<td>{{ cell }}</td>{% endfor %}</tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- provide /stats JSON endpoint and /charts page with bar chart
- add /query admin route for running ad hoc SQL

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5eb7a7d088333871b17eeab43e963