### PR TITLE
Add navigation, hits API, forecast dashboard, and admin DB GUI

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,12 +10,18 @@
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
       <div class="container-fluid">
-        <a class="navbar-brand" href="{{ url_for('dashboard.dashboard') }}">DiyaaHoney</a>
-        {% if current_user.is_authenticated %}
-        <div class="d-flex">
-          <a class="nav-link text-white" href="{{ url_for('dashboard.logout') }}">Logout</a>
+        <a class="navbar-brand" href="{{ url_for('dashboard.home') }}">DiyaaHoney</a>
+        <div class="navbar-nav">
+          <a class="nav-link" href="{{ url_for('dashboard.home') }}">Home</a>
+          <a class="nav-link" href="{{ url_for('dashboard.hits') }}">Hits</a>
+          <a class="nav-link" href="{{ url_for('dashboard.dashboard') }}">Dashboard</a>
+          {% if current_user.is_authenticated and current_user.role == 'admin' %}
+          <a class="nav-link" href="{{ url_for('dashboard.dbgui') }}">DB GUI</a>
+          {% endif %}
+          {% if current_user.is_authenticated %}
+          <a class="nav-link" href="{{ url_for('dashboard.logout') }}">Logout</a>
+          {% endif %}
         </div>
-        {% endif %}
       </div>
     </nav>
     <div class="container">

--- a/templates/dbgui.html
+++ b/templates/dbgui.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>DB GUI</h1>
+<ul>
+  {% for t in tables %}<li>{{ t }}</li>{% endfor %}
+</ul>
+<form method="post" class="mb-3">
+  <textarea name="sql" class="form-control" rows="3">{{ sql }}</textarea>
+  <button class="btn btn-primary mt-2" type="submit">Run</button>
+</form>
+{% if rows %}
+<table class="table table-striped">
+  <thead>
+    <tr>
+      {% for h in headers %}<th>{{ h }}</th>{% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>{% for cell in row %}<td>{{ cell }}</td>{% endfor %}</tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Forecast</h1>
+<form id="filter-form" class="row g-3 mb-3">
+  <div class="col-md-3"><input type="text" name="ip" class="form-control" placeholder="IP"></div>
+  <div class="col-md-3"><input type="date" name="start" class="form-control"></div>
+  <div class="col-md-3"><input type="date" name="end" class="form-control"></div>
+  <div class="col-md-3"><button class="btn btn-primary" type="submit">Apply</button></div>
+</form>
+<canvas id="stats-chart"></canvas>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const ctx = document.getElementById('stats-chart').getContext('2d');
+let chart = new Chart(ctx, {type:'bar', data:{labels:[], datasets:[{label:'Hits', data:[]}]} });
+async function updateChart(){
+  const formData = new FormData(document.getElementById('filter-form'));
+  const params = new URLSearchParams(formData).toString();
+  const res = await fetch(`{{ url_for('dashboard.api_stats') }}?${params}`);
+  const data = await res.json();
+  chart.data.labels = data.map(d => d.ip);
+  chart.data.datasets[0].data = data.map(d => d.hits);
+  chart.update();
+}
+document.getElementById('filter-form').addEventListener('submit', e => {
+  e.preventDefault();
+  updateChart();
+});
+updateChart();
+</script>
+{% endblock %}

--- a/templates/hits.html
+++ b/templates/hits.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Hits</h1>
+<table class="table">
+  <thead><tr><th>IP</th><th>Hits</th></tr></thead>
+  <tbody id="hits-body"></tbody>
+</table>
+<script>
+async function loadHits(){
+  const res = await fetch("{{ url_for('dashboard.api_hits') }}");
+  const data = await res.json();
+  const body = document.getElementById("hits-body");
+  body.innerHTML = data.map(r => `<tr><td>${r.ip}</td><td>${r.hits}</td></tr>`).join("");
+}
+loadHits();
+setInterval(loadHits, 5000);
+</script>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Welcome to DiyaaHoney</h1>
+<p>The platform supports two business processes:</p>
+<ul>
+  <li>Security Incident Detection &amp; Response</li>
+  <li>System Administration &amp; Reporting</li>
+</ul>
+<p>Key use cases:</p>
+<ul>
+  <li>Record Connection</li>
+  <li>Auto-Alert on Brute-Force</li>
+  <li>User Login</li>
+  <li>Search Connections</li>
+  <li>Purge Old Data</li>
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add sitewide navigation bar with links to Home, Hits, Dashboard, DB GUI, and Logout
- Implement simulated hits API and live updating Hits page
- Build forecast dashboard with filter form and stats API
- Provide admin-only DB GUI for read-only SQL queries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5eff396b4833386b772bea6f637e1